### PR TITLE
feat: add consent flow for recording

### DIFF
--- a/backend/routes/consent.ts
+++ b/backend/routes/consent.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+const router = Router();
+
+const dbPromise = open({
+  filename: './data.sqlite',
+  driver: sqlite3.Database,
+});
+
+router.post('/', async (req, res) => {
+  const { userId, consent } = req.body;
+  const db = await dbPromise;
+  await db.exec(`CREATE TABLE IF NOT EXISTS consents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT,
+    consent INTEGER,
+    time TEXT,
+    ip TEXT,
+    user_agent TEXT
+  )`);
+
+  const time = new Date().toISOString();
+  const ip = req.ip;
+  const ua = req.get('User-Agent') || '';
+
+  try {
+    await db.run(
+      'INSERT INTO consents (user_id, consent, time, ip, user_agent) VALUES (?, ?, ?, ?, ?)',
+      userId,
+      consent ? 1 : 0,
+      time,
+      ip,
+      ua
+    );
+    res.status(201).json({ ok: true });
+  } catch (err) {
+    res.status(500).json({ error: 'failed to save consent' });
+  }
+});
+
+export default router;
+

--- a/frontend/components/ConsentModal.tsx
+++ b/frontend/components/ConsentModal.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+
+interface ConsentModalProps {
+  userId: string;
+  onStart: () => void;
+}
+
+const ConsentModal: React.FC<ConsentModalProps> = ({ userId, onStart }) => {
+  const [checked, setChecked] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submitConsent = async () => {
+    setSubmitting(true);
+    try {
+      await fetch('/api/consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, consent: true }),
+      });
+      onStart();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h2>録音への同意</h2>
+        <label>
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+          />
+          録音に同意します
+        </label>
+        <button onClick={submitConsent} disabled={!checked || submitting}>
+          録音開始
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ConsentModal;
+


### PR DESCRIPTION
## Summary
- add consent modal with checkbox gating recording start
- store consent records with audit info via new backend route

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad64082e50833184cdfa4575a46ccb