### PR TITLE
feat: add audio recording hook and upload route

### DIFF
--- a/backend/routes/uploadAudio.ts
+++ b/backend/routes/uploadAudio.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import multer from 'multer';
+
+const router = Router();
+const upload = multer({ dest: 'uploads/' });
+
+/**
+ * POST /api/uploadAudio
+ * Receives audio blob and stores it temporarily.
+ */
+router.post('/uploadAudio', upload.single('audio'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ message: 'No audio uploaded' });
+  }
+  // For demo purposes we simply acknowledge receipt of the file.
+  res.json({ message: 'Audio uploaded', file: req.file.filename });
+});
+
+export default router;

--- a/frontend/components/RecorderControls.tsx
+++ b/frontend/components/RecorderControls.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useRecorder } from '../hooks/useRecorder';
+import RecordingIndicator from './RecordingIndicator';
+
+/**
+ * RecorderControls provides buttons to control the MediaRecorder
+ * via the useRecorder hook.
+ */
+const RecorderControls: React.FC = () => {
+  const { start, pause, resume, stop, isRecording, isPaused } = useRecorder();
+
+  const handleStop = async () => {
+    if (window.confirm('録音を終了しますか？')) {
+      await stop();
+    }
+  };
+
+  return (
+    <div>
+      <button onClick={start} disabled={isRecording && !isPaused}>
+        録音
+      </button>
+      <button onClick={isPaused ? resume : pause} disabled={!isRecording}>
+        {isPaused ? '再開' : '一時停止'}
+      </button>
+      <button onClick={handleStop} disabled={!isRecording}>
+        終了
+      </button>
+      {isRecording && !isPaused && <RecordingIndicator />}
+    </div>
+  );
+};
+
+export default RecorderControls;

--- a/frontend/components/RecordingIndicator.tsx
+++ b/frontend/components/RecordingIndicator.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/**
+ * RecordingIndicator clearly shows when the microphone is recording.
+ */
+export const RecordingIndicator: React.FC = () => {
+  return (
+    <div style={{ color: 'red', fontWeight: 'bold' }}>
+      ● Recording...
+    </div>
+  );
+};
+
+export default RecordingIndicator;

--- a/frontend/hooks/useRecorder.ts
+++ b/frontend/hooks/useRecorder.ts
@@ -1,0 +1,80 @@
+import { useRef, useState } from 'react';
+
+interface RecorderControls {
+  start: () => Promise<void>;
+  pause: () => void;
+  resume: () => void;
+  stop: () => Promise<void>;
+  isRecording: boolean;
+  isPaused: boolean;
+}
+
+/**
+ * useRecorder provides MediaRecorder control helpers.
+ * It exposes start/pause/resume/stop functions and handles
+ * uploading the recorded audio to the backend.
+ */
+export function useRecorder(): RecorderControls {
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const chunksRef = useRef<Blob[]>([]);
+
+  const start = async () => {
+    if (isRecording) return;
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const mediaRecorder = new MediaRecorder(stream);
+    chunksRef.current = [];
+    mediaRecorder.ondataavailable = (e) => {
+      if (e.data.size > 0) {
+        chunksRef.current.push(e.data);
+      }
+    };
+    mediaRecorder.start();
+    mediaRecorderRef.current = mediaRecorder;
+    setIsRecording(true);
+    setIsPaused(false);
+  };
+
+  const pause = () => {
+    const mr = mediaRecorderRef.current;
+    if (mr && mr.state === 'recording') {
+      mr.pause();
+      setIsPaused(true);
+    }
+  };
+
+  const resume = () => {
+    const mr = mediaRecorderRef.current;
+    if (mr && mr.state === 'paused') {
+      mr.resume();
+      setIsPaused(false);
+    }
+  };
+
+  const stop = async () => {
+    const mr = mediaRecorderRef.current;
+    if (!mr) return;
+    return new Promise<void>((resolve) => {
+      mr.onstop = async () => {
+        setIsRecording(false);
+        setIsPaused(false);
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const formData = new FormData();
+        formData.append('audio', blob, 'recording.webm');
+        try {
+          await fetch('/api/uploadAudio', {
+            method: 'POST',
+            body: formData,
+          });
+        } catch (e) {
+          console.error('Failed to upload audio', e);
+        }
+        resolve();
+      };
+      mr.stop();
+    });
+  };
+
+  return { start, pause, resume, stop, isRecording, isPaused };
+}


### PR DESCRIPTION
## Summary
- add MediaRecorder hook with start/pause/resume/stop and upload to backend
- add recorder controls and indicator components
- implement backend upload route

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad640fc9b48331b76f03168d28e5e9