### PR TITLE
Add transcription service and view

### DIFF
--- a/backend/db/transcriptions.ts
+++ b/backend/db/transcriptions.ts
@@ -1,0 +1,42 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export interface TranscriptionSegment {
+  text: string;
+  start: number;
+  end: number;
+  speaker?: string;
+}
+
+export interface TranscriptionRecord {
+  id: string;
+  segments: TranscriptionSegment[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// simple in-memory store; replace with real DB in production
+const store: Map<string, TranscriptionRecord> = new Map();
+
+export function saveTranscription(segments: TranscriptionSegment[]): TranscriptionRecord {
+  const id = uuidv4();
+  const record: TranscriptionRecord = {
+    id,
+    segments,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  store.set(id, record);
+  return record;
+}
+
+export function getTranscription(id: string): TranscriptionRecord | undefined {
+  return store.get(id);
+}
+
+export function updateTranscription(id: string, segments: TranscriptionSegment[]): TranscriptionRecord | undefined {
+  const existing = store.get(id);
+  if (!existing) return undefined;
+  const updated: TranscriptionRecord = { ...existing, segments, updatedAt: new Date() };
+  store.set(id, updated);
+  return updated;
+}

--- a/backend/routes/transcriptions.ts
+++ b/backend/routes/transcriptions.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { getTranscription, updateTranscription, TranscriptionSegment } from '../db/transcriptions';
+
+const router = express.Router();
+
+// retrieve transcription for polling
+router.get('/:id', (req, res) => {
+  const record = getTranscription(req.params.id);
+  if (!record) return res.sendStatus(404);
+  res.json(record);
+});
+
+// update transcription after user edits
+router.put('/:id', (req, res) => {
+  const segments = req.body.segments as TranscriptionSegment[];
+  const record = updateTranscription(req.params.id, segments);
+  if (!record) return res.sendStatus(404);
+  res.json(record);
+});
+
+export default router;

--- a/backend/services/transcription.ts
+++ b/backend/services/transcription.ts
@@ -1,0 +1,34 @@
+import OpenAI from 'openai';
+import fs from 'fs';
+import {
+  saveTranscription,
+  TranscriptionSegment,
+  TranscriptionRecord,
+} from '../db/transcriptions';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+/**
+ * Transcribe an audio file using OpenAI Whisper.
+ * Japanese language and medical vocabulary are requested.
+ * Speaker diarization and timestamps are enabled.
+ */
+export async function transcribeAudio(filePath: string): Promise<TranscriptionRecord> {
+  const response: any = await client.audio.transcriptions.create({
+    file: fs.createReadStream(filePath),
+    model: 'gpt-4o-transcribe', // or 'whisper-1'
+    language: 'ja',
+    prompt: '医療用語',
+    response_format: 'verbose_json',
+    diarization: true,
+  });
+
+  const segments: TranscriptionSegment[] = (response.segments || []).map((s: any) => ({
+    text: s.text,
+    start: s.start,
+    end: s.end,
+    speaker: s.speaker,
+  }));
+
+  return saveTranscription(segments);
+}

--- a/backend/ws/transcription.ts
+++ b/backend/ws/transcription.ts
@@ -1,0 +1,27 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import { TranscriptionSegment } from '../db/transcriptions';
+
+interface Client {
+  id: string;
+  ws: WebSocket;
+}
+
+const clients: Client[] = [];
+
+export function startTranscriptionWS(server: any) {
+  const wss = new WebSocketServer({ server, path: '/ws/transcriptions' });
+  wss.on('connection', (ws, req) => {
+    const url = new URL(req.url || '', 'http://localhost');
+    const id = url.pathname.split('/').pop() || '';
+    clients.push({ id, ws });
+    ws.on('close', () => {
+      const idx = clients.findIndex((c) => c.ws === ws);
+      if (idx >= 0) clients.splice(idx, 1);
+    });
+  });
+}
+
+export function broadcastSegment(id: string, segment: TranscriptionSegment) {
+  const message = JSON.stringify({ segments: [segment] });
+  clients.filter((c) => c.id === id).forEach((c) => c.ws.send(message));
+}

--- a/frontend/TranscriptionView.tsx
+++ b/frontend/TranscriptionView.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+
+interface Segment {
+  text: string;
+  start: number;
+  end: number;
+  speaker?: string;
+}
+
+export default function TranscriptionView({ transcriptionId }: { transcriptionId: string }) {
+  const [segments, setSegments] = useState<Segment[]>([]);
+
+  useEffect(() => {
+    const ws = new WebSocket(`ws://localhost:4000/ws/transcriptions/${transcriptionId}`);
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      setSegments((prev) => [...prev, ...(data.segments || [])]);
+    };
+    return () => ws.close();
+  }, [transcriptionId]);
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const res = await fetch(`/api/transcriptions/${transcriptionId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setSegments(data.segments || []);
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [transcriptionId]);
+
+  const updateSegment = (index: number, text: string) => {
+    setSegments((prev) => {
+      const copy = [...prev];
+      copy[index] = { ...copy[index], text };
+      return copy;
+    });
+  };
+
+  const saveEdits = async () => {
+    await fetch(`/api/transcriptions/${transcriptionId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ segments }),
+    });
+  };
+
+  return (
+    <div>
+      {segments.map((seg, i) => (
+        <div key={i}>
+          <span>
+            [{seg.start.toFixed(1)}-{seg.end.toFixed(1)}] (S{seg.speaker ?? '?'})
+          </span>
+          <input value={seg.text} onChange={(e) => updateSegment(i, e.target.value)} />
+        </div>
+      ))}
+      <button onClick={saveEdits}>保存</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add OpenAI-based transcription service with diarization and Japanese medical vocabulary
- implement in-memory transcription store with edit API
- add TranscriptionView component using WebSocket updates and polling

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ad6415d84c83318e9bd77d4cb958af