### PR TITLE
Add summary generation service and frontend view

### DIFF
--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS summary (
+  id SERIAL PRIMARY KEY,
+  patient_id VARCHAR(255) NOT NULL,
+  clinician_summary TEXT NOT NULL,
+  todo_list TEXT NOT NULL,
+  patient_text TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/backend/services/summary.ts
+++ b/backend/services/summary.ts
@@ -1,0 +1,63 @@
+import OpenAI from 'openai';
+import { Pool } from 'pg';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+export interface SummaryResult {
+  clinicianSummary: string[];
+  todoList: string[];
+  patientText: string;
+}
+
+export async function generateSummary(soap: string): Promise<SummaryResult> {
+  const prompt = `You are a medical assistant helping clinicians summarize SOAP notes.
+Extract exactly three bullet points for clinicians, a to-do list, and rewrite the note in plain language for the patient.
+Return JSON with keys: clinicianSummary (array of three strings), todoList (array of strings), patientText.`;
+
+  const response = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages: [
+      { role: 'system', content: prompt },
+      { role: 'user', content: soap }
+    ],
+    temperature: 0.2
+  });
+
+  const content = response.choices[0]?.message?.content || '{}';
+  const data = JSON.parse(content);
+
+  return {
+    clinicianSummary: data.clinicianSummary || [],
+    todoList: data.todoList || [],
+    patientText: data.patientText || ''
+  };
+}
+
+export async function saveSummary(patientId: string, result: SummaryResult): Promise<void> {
+  await pool.query(
+    `INSERT INTO summary (patient_id, clinician_summary, todo_list, patient_text) VALUES ($1,$2,$3,$4)`,
+    [
+      patientId,
+      JSON.stringify(result.clinicianSummary),
+      JSON.stringify(result.todoList),
+      result.patientText
+    ]
+  );
+}
+
+export async function getSummaries(patientId: string) {
+  const { rows } = await pool.query(
+    `SELECT id, clinician_summary, todo_list, patient_text, created_at FROM summary WHERE patient_id = $1 ORDER BY created_at DESC`,
+    [patientId]
+  );
+
+  return rows.map(row => ({
+    id: row.id,
+    clinicianSummary: JSON.parse(row.clinician_summary),
+    todoList: JSON.parse(row.todo_list),
+    patientText: row.patient_text,
+    createdAt: row.created_at
+  }));
+}
+

--- a/frontend/components/SummaryView.tsx
+++ b/frontend/components/SummaryView.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+
+interface SummaryViewProps {
+  initialSummary: string[];
+  initialTodo: string[];
+  patientText: string;
+  onChange?: (summary: string[], todo: string[], patientText: string) => void;
+}
+
+const SummaryView: React.FC<SummaryViewProps> = ({
+  initialSummary,
+  initialTodo,
+  patientText: initialPatientText,
+  onChange
+}) => {
+  const [summary, setSummary] = useState<string[]>(initialSummary);
+  const [todo, setTodo] = useState<string[]>(initialTodo);
+  const [patientText, setPatientText] = useState<string>(initialPatientText);
+
+  const updateSummary = (index: number, value: string) => {
+    const next = [...summary];
+    next[index] = value;
+    setSummary(next);
+    onChange?.(next, todo, patientText);
+  };
+
+  const updateTodo = (index: number, value: string) => {
+    const next = [...todo];
+    next[index] = value;
+    setTodo(next);
+    onChange?.(summary, next, patientText);
+  };
+
+  const updatePatientText = (value: string) => {
+    setPatientText(value);
+    onChange?.(summary, todo, value);
+  };
+
+  const addSummary = () => {
+    const next = [...summary, ''];
+    setSummary(next);
+  };
+
+  const addTodo = () => {
+    const next = [...todo, ''];
+    setTodo(next);
+  };
+
+  return (
+    <div>
+      <h2>Summary</h2>
+      <ul>
+        {summary.map((item, i) => (
+          <li key={i}>
+            <input
+              type="text"
+              value={item}
+              onChange={e => updateSummary(i, e.target.value)}
+            />
+          </li>
+        ))}
+      </ul>
+      <button onClick={addSummary}>Add Summary Item</button>
+
+      <h2>To-Do</h2>
+      <ul>
+        {todo.map((item, i) => (
+          <li key={i}>
+            <input
+              type="text"
+              value={item}
+              onChange={e => updateTodo(i, e.target.value)}
+            />
+          </li>
+        ))}
+      </ul>
+      <button onClick={addTodo}>Add To-Do Item</button>
+
+      <h2>Patient Explanation</h2>
+      <textarea
+        value={patientText}
+        onChange={e => updatePatientText(e.target.value)}
+      />
+    </div>
+  );
+};
+
+export default SummaryView;
+


### PR DESCRIPTION
## Summary
- add backend service that uses GPT-4 to produce clinician summary, to-do list, and patient-friendly text
- persist summary results in a new `summary` table
- create React component to display and edit summary data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad64184fc48331a2c72f16850adf36