### PR TITLE
feat: add disclaimer component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Text to display in the Disclaimer component. Set after legal review.
+NEXT_PUBLIC_DISCLAIMER_TEXT="このコンテンツは医療助言を目的としたものではありません。緊急の場合は医療機関を受診してください。"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # yorisoi-demo
+
 よりそいのデモです
+
+## Disclaimer
+
+サマリー画面および共有リンク画面のフッターに免責事項が表示されます。文言は `NEXT_PUBLIC_DISCLAIMER_TEXT` 環境変数で管理しており、法務確認後に設定してください。

--- a/frontend/components/Disclaimer.tsx
+++ b/frontend/components/Disclaimer.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+/**
+ * Displays a disclaimer about the non-medical nature of the tool and guidance on seeking emergency care.
+ *
+ * The actual text should be provided via the `NEXT_PUBLIC_DISCLAIMER_TEXT` environment variable so that
+ * legal teams can update the copy without requiring code changes.
+ */
+export const Disclaimer: React.FC = () => {
+  const defaultText =
+    'このコンテンツは医療助言を目的としたものではありません。緊急の場合は医療機関を受診してください。';
+  const text = process.env.NEXT_PUBLIC_DISCLAIMER_TEXT ?? defaultText;
+
+  return (
+    <div className="text-xs text-gray-500 mt-4">
+      <p>{text}</p>
+    </div>
+  );
+};
+
+export default Disclaimer;

--- a/frontend/pages/ShareLink.tsx
+++ b/frontend/pages/ShareLink.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Disclaimer from '../components/Disclaimer';
+
+/**
+ * Placeholder share link view displaying the Disclaimer component in the footer.
+ */
+const ShareLink: React.FC = () => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <main className="flex-grow">
+        <h1>Share Link View</h1>
+        <p>ここに共有リンクの詳細が表示されます。</p>
+      </main>
+      <footer>
+        <Disclaimer />
+      </footer>
+    </div>
+  );
+};
+
+export default ShareLink;

--- a/frontend/pages/Summary.tsx
+++ b/frontend/pages/Summary.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Disclaimer from '../components/Disclaimer';
+
+/**
+ * Placeholder summary view showing how to include the Disclaimer component in the footer.
+ */
+const Summary: React.FC = () => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <main className="flex-grow">
+        <h1>Summary View</h1>
+        <p>ここにサマリー情報が表示されます。</p>
+      </main>
+      <footer>
+        <Disclaimer />
+      </footer>
+    </div>
+  );
+};
+
+export default Summary;


### PR DESCRIPTION
## Summary
- add Disclaimer component for non-medical guidance and emergency instructions
- render Disclaimer in summary and share link view footers
- manage disclaimer text via `NEXT_PUBLIC_DISCLAIMER_TEXT` environment variable and document usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad641f05ec833187f61995b832df3e