### PR TITLE
Add Express server with routes and WebSocket

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import http from 'http';
+
+import uploadAudioRouter from './routes/uploadAudio';
+import transcriptionsRouter from './routes/transcriptions';
+import consentRouter from './routes/consent';
+import shareRouter from './routes/share';
+import { startTranscriptionWS } from './ws/transcription';
+
+const app = express();
+app.use(express.json());
+
+app.use('/api', uploadAudioRouter);
+app.use('/api/transcriptions', transcriptionsRouter);
+app.use('/api/consent', consentRouter);
+app.use('/api', shareRouter);
+
+const server = http.createServer(app);
+startTranscriptionWS(server);
+
+const PORT = 4000;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add backend/server.ts to initialize Express app, HTTP server, and WebSocket
- mount audio upload, transcription, consent, and share routes
- start server on port 4000 and log startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad684ec7d48331bd70434afdccba9f