### PR TITLE
Handle microphone permission errors in recorder hook

### DIFF
--- a/frontend/hooks/useRecorder.ts
+++ b/frontend/hooks/useRecorder.ts
@@ -22,7 +22,15 @@ export function useRecorder(): RecorderControls {
 
   const start = async () => {
     if (isRecording) return;
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e) {
+      console.error('Failed to obtain microphone access', e);
+      alert('マイクの権限を取得できませんでした。');
+      setIsRecording(false);
+      return;
+    }
     const mediaRecorder = new MediaRecorder(stream);
     chunksRef.current = [];
     mediaRecorder.ondataavailable = (e) => {


### PR DESCRIPTION
## Summary
- handle microphone permission errors when starting recorder
- notify users of microphone access failures and avoid starting recording

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6855b17083319b54c596c7fed786