### PR TITLE
Remove temp uploads and schedule cleanup

### DIFF
--- a/backend/routes/uploadAudio.ts
+++ b/backend/routes/uploadAudio.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import multer from 'multer';
+import fs from 'fs';
 
 const router = Router();
 const upload = multer({ dest: 'uploads/' });
@@ -12,8 +13,16 @@ router.post('/uploadAudio', upload.single('audio'), (req, res) => {
   if (!req.file) {
     return res.status(400).json({ message: 'No audio uploaded' });
   }
+
+  const filePath = req.file.path;
   // For demo purposes we simply acknowledge receipt of the file.
   res.json({ message: 'Audio uploaded', file: req.file.filename });
+
+  fs.unlink(filePath, (err) => {
+    if (err) {
+      console.error('Failed to remove temporary file:', err);
+    }
+  });
 });
 
 export default router;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -6,6 +6,7 @@ import transcriptionsRouter from './routes/transcriptions';
 import consentRouter from './routes/consent';
 import shareRouter from './routes/share';
 import { startTranscriptionWS } from './ws/transcription';
+import { cleanupUploads } from './utils/cleanupUploads';
 
 const app = express();
 app.use(express.json());
@@ -17,6 +18,9 @@ app.use('/api', shareRouter);
 
 const server = http.createServer(app);
 startTranscriptionWS(server);
+
+cleanupUploads();
+setInterval(cleanupUploads, 60 * 60 * 1000);
 
 const PORT = 4000;
 server.listen(PORT, () => {

--- a/backend/utils/cleanupUploads.ts
+++ b/backend/utils/cleanupUploads.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+const UPLOADS_DIR = path.join(__dirname, '..', '..', 'uploads');
+
+export function cleanupUploads() {
+  fs.readdir(UPLOADS_DIR, (err, files) => {
+    if (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error('Failed to read uploads directory:', err);
+      }
+      return;
+    }
+
+    files.forEach((file) => {
+      const filePath = path.join(UPLOADS_DIR, file);
+      fs.unlink(filePath, (unlinkErr) => {
+        if (unlinkErr) {
+          console.error(`Failed to remove temporary file ${filePath}:`, unlinkErr);
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- delete uploaded audio files after processing
- add utility to clean stale files in uploads directory
- schedule periodic cleanup when server starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6b1282ac83319dd90e66a822fc4f