### PR TITLE
Use async file operations for share storage

### DIFF
--- a/backend/scripts/cleanupExpiredLinks.ts
+++ b/backend/scripts/cleanupExpiredLinks.ts
@@ -1,4 +1,6 @@
 import { removeExpired } from '../utils/sharesStore';
 
-const removed = removeExpired();
-console.log(`Removed ${removed} expired links`);
+(async () => {
+  const removed = await removeExpired();
+  console.log(`Removed ${removed} expired links`);
+})();

--- a/backend/utils/sharesStore.ts
+++ b/backend/utils/sharesStore.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 
@@ -11,45 +11,72 @@ export interface ShareRecord {
 
 const DATA_PATH = path.join(__dirname, '..', 'data', 'shares.json');
 
-function load(): ShareRecord[] {
-  try {
-    const raw = fs.readFileSync(DATA_PATH, 'utf-8');
-    return JSON.parse(raw);
-  } catch {
-    return [];
+class Mutex {
+  private mutex = Promise.resolve();
+  async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void;
+    const p = new Promise<void>(res => (release = res));
+    const prev = this.mutex;
+    this.mutex = prev.then(() => p);
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
   }
 }
 
-function save(records: ShareRecord[]) {
-  fs.writeFileSync(DATA_PATH, JSON.stringify(records, null, 2));
+const fileMutex = new Mutex();
+
+async function load(): Promise<ShareRecord[]> {
+  try {
+    const raw = await fs.readFile(DATA_PATH, 'utf-8');
+    return JSON.parse(raw);
+  } catch (err: any) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
 }
 
-export function createShare(content: string, expiresInSeconds: number, password?: string): ShareRecord {
-  const records = load();
-  const token = crypto.randomBytes(16).toString('hex');
-  const expiresAt = Date.now() + expiresInSeconds * 1000;
-  const passwordHash = password ? crypto.createHash('sha256').update(password).digest('hex') : undefined;
-  const record: ShareRecord = { token, content, expiresAt, passwordHash };
-  records.push(record);
-  save(records);
-  return record;
+async function save(records: ShareRecord[]) {
+  const tmpPath = `${DATA_PATH}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(records, null, 2), 'utf-8');
+  await fs.rename(tmpPath, DATA_PATH);
 }
 
-export function findShare(token: string): ShareRecord | undefined {
-  const records = load();
+export async function createShare(content: string, expiresInSeconds: number, password?: string): Promise<ShareRecord> {
+  return fileMutex.runExclusive(async () => {
+    const records = await load();
+    const token = crypto.randomBytes(16).toString('hex');
+    const expiresAt = Date.now() + expiresInSeconds * 1000;
+    const passwordHash = password ? crypto.createHash('sha256').update(password).digest('hex') : undefined;
+    const record: ShareRecord = { token, content, expiresAt, passwordHash };
+    records.push(record);
+    await save(records);
+    return record;
+  });
+}
+
+export async function findShare(token: string): Promise<ShareRecord | undefined> {
+  const records = await load();
   return records.find(r => r.token === token);
 }
 
-export function removeShare(token: string) {
-  const records = load().filter(r => r.token !== token);
-  save(records);
+export async function removeShare(token: string): Promise<void> {
+  await fileMutex.runExclusive(async () => {
+    const records = (await load()).filter(r => r.token !== token);
+    await save(records);
+  });
 }
 
-export function removeExpired(): number {
-  const now = Date.now();
-  const records = load();
-  const valid = records.filter(r => r.expiresAt > now);
-  const removed = records.length - valid.length;
-  if (removed > 0) save(valid);
-  return removed;
+export async function removeExpired(): Promise<number> {
+  return fileMutex.runExclusive(async () => {
+    const now = Date.now();
+    const records = await load();
+    const valid = records.filter(r => r.expiresAt > now);
+    const removed = records.length - valid.length;
+    if (removed > 0) await save(valid);
+    return removed;
+  });
 }


### PR DESCRIPTION
## Summary
- replace synchronous share store file operations with async fs promises and atomic writes
- add simple mutex to serialize modifications and prevent race conditions
- update share routes and cleanup script to use async API

## Testing
- `npm test`
- `npx tsc backend/utils/sharesStore.ts backend/routes/share.ts backend/scripts/cleanupExpiredLinks.ts --lib es2020,dom --module commonjs --target es2020 --types node --esModuleInterop --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68ad6b190af483318cb61e6bd90bfd24