### PR TITLE
feat(frontend): add WS URL env var

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,6 @@
+# Frontend
+
+## Environment Variables
+
+- `NEXT_PUBLIC_WS_URL`: Base URL for WebSocket connections used by `TranscriptionView` to receive transcription updates.
+  Defaults to `ws://localhost:4000` when not set.

--- a/frontend/TranscriptionView.tsx
+++ b/frontend/TranscriptionView.tsx
@@ -11,7 +11,8 @@ export default function TranscriptionView({ transcriptionId }: { transcriptionId
   const [segments, setSegments] = useState<Segment[]>([]);
 
   useEffect(() => {
-    const ws = new WebSocket(`ws://localhost:4000/ws/transcriptions/${transcriptionId}`);
+    const wsBaseUrl = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:4000";
+    const ws = new WebSocket(`${wsBaseUrl}/ws/transcriptions/${transcriptionId}`);
     ws.onmessage = (event) => {
       const data = JSON.parse(event.data);
       setSegments((prev) => [...prev, ...(data.segments || [])]);


### PR DESCRIPTION
## Summary
- allow configuring WebSocket base URL via `NEXT_PUBLIC_WS_URL` with localhost fallback
- document new env var in frontend README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad6b1b50ac8331a4adf861fa0bb687