### PR TITLE
Remove stray lines and duplicate log path constant

### DIFF
--- a/backend/routes/share.ts
+++ b/backend/routes/share.ts
@@ -5,9 +5,6 @@ import path from 'path';
 import { createShare, findShare, removeShare } from '../utils/sharesStore';
 
 const router = Router();
-main
-=======
-const LOG_PATH = path.join(__dirname, '..', 'logs', 'access.log');
 const MAX_CONTENT_BYTES = 1024 * 1024; // 1 MB limit
 
 const LOG_DIR = path.join(__dirname, '..', 'logs');


### PR DESCRIPTION
## Summary
- clean share route by removing leftover merge markers
- define LOG_DIR/LOG_PATH only once in share route

## Testing
- `npx tsc backend/routes/share.ts --noEmit --esModuleInterop`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad74f69c5c83319b81bdfc2d6d0709