### PR TITLE
Initialize consent table during server startup

### DIFF
--- a/backend/routes/consent.ts
+++ b/backend/routes/consent.ts
@@ -9,8 +9,7 @@ const dbPromise = open({
   driver: sqlite3.Database,
 });
 
-router.post('/', async (req, res) => {
-  const { userId, consent } = req.body;
+export async function initConsentTable() {
   const db = await dbPromise;
   await db.exec(`CREATE TABLE IF NOT EXISTS consents (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -20,6 +19,11 @@ router.post('/', async (req, res) => {
     ip TEXT,
     user_agent TEXT
   )`);
+}
+
+router.post('/', async (req, res) => {
+  const { userId, consent } = req.body;
+  const db = await dbPromise;
 
   const time = new Date().toISOString();
   const ip = req.ip;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -3,26 +3,32 @@ import http from 'http';
 
 import uploadAudioRouter from './routes/uploadAudio';
 import transcriptionsRouter from './routes/transcriptions';
-import consentRouter from './routes/consent';
+import consentRouter, { initConsentTable } from './routes/consent';
 import shareRouter from './routes/share';
 import { startTranscriptionWS } from './ws/transcription';
 import { cleanupUploads } from './utils/cleanupUploads';
 
-const app = express();
-app.use(express.json());
+async function startServer() {
+  await initConsentTable();
 
-app.use('/api', uploadAudioRouter);
-app.use('/api/transcriptions', transcriptionsRouter);
-app.use('/api/consent', consentRouter);
-app.use('/api', shareRouter);
+  const app = express();
+  app.use(express.json());
 
-const server = http.createServer(app);
-startTranscriptionWS(server);
+  app.use('/api', uploadAudioRouter);
+  app.use('/api/transcriptions', transcriptionsRouter);
+  app.use('/api/consent', consentRouter);
+  app.use('/api', shareRouter);
 
-cleanupUploads();
-setInterval(cleanupUploads, 60 * 60 * 1000);
+  const server = http.createServer(app);
+  startTranscriptionWS(server);
 
-const PORT = 4000;
-server.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+  cleanupUploads();
+  setInterval(cleanupUploads, 60 * 60 * 1000);
+
+  const PORT = 4000;
+  server.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+startServer();


### PR DESCRIPTION
## Summary
- Move `CREATE TABLE IF NOT EXISTS` from consent POST handler to `initConsentTable` function
- Initialize consent table during server startup before registering routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad74f9ac5c8331b58dd4d3c4a492fa